### PR TITLE
Priorizar S DE LEON en  google 

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,9 +1,15 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>S DE LEON</title>
+    
+    <!-- SEO Esencial para Google -->
+    <title>S DE LEON - Servicios de Transporte en Guatemala</title>
+    <meta name="description" content="S DE LEON ofrece servicios de transporte de alta calidad en Guatemala. Transporte seguro, confiable y profesional. Conoce nuestros servicios, ubicación y contáctanos." />
+    <meta name="keywords" content="S DE LEON, servicios de transporte, Guatemala, transporte seguro, transporte confiable, transporte profesional, contacto Guatemala" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://sdeleonglobalsgt.com/" />
   </head>
   <body>
     <div id="root"></div>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,4 @@
-# https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow:
+Allow: /
+
+Sitemap: https://sdeleonglobalsgt.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://sdeleonglobalsgt.com/</loc>
+    <lastmod>2024-01-15</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://sdeleonglobalsgt.com/about</loc>
+    <lastmod>2024-01-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://sdeleonglobalsgt.com/services</loc>
+    <lastmod>2024-01-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://sdeleonglobalsgt.com/contact</loc>
+    <lastmod>2024-01-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://sdeleonglobalsgt.com/location</loc>
+    <lastmod>2024-01-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
Priorizar S DE LEON en keywords
 "S DE LEON" primero para que Google entienda que tu página es principalmente sobre "S DE LEON", no solo sobre transporte.orte.